### PR TITLE
Shim customElements.get

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,6 +1,9 @@
 if (typeof process !== 'undefined') {
   global.HTMLElement = function() { return {} }
-  global.customElements = { define: function() { } }
+  global.customElements = {
+    define: function() { },
+    get: function() { }
+  }
   global.Worker = function() { return { postMessage: function() { } } }
 }
 


### PR DESCRIPTION
Keeps SSR from blowing up when user checks the existence of a custom element.